### PR TITLE
Fixes #323 Document Service end point does not consider the "increment" field during checkin operation

### DIFF
--- a/src/main/java/com/openkm/rest/endpoint/DocumentService.java
+++ b/src/main/java/com/openkm/rest/endpoint/DocumentService.java
@@ -296,6 +296,7 @@ public class DocumentService {
 			String docId = null;
 			String comment = null;
 			InputStream is = null;
+			int increment = 0;
 
 			for (Attachment att : atts) {
 				if ("docId".equals(att.getContentDisposition().getParameter("name"))) {
@@ -304,11 +305,13 @@ public class DocumentService {
 					comment = att.getObject(String.class);
 				} else if ("content".equals(att.getContentDisposition().getParameter("name"))) {
 					is = att.getDataHandler().getInputStream();
-				}
+				} else if ("increment".equals(att.getContentDisposition().getParameter("name"))) {
+					increment = Integer.parseInt(att.getObject(String.class));
+				} 
 			}
 
 			DocumentModule dm = ModuleManager.getDocumentModule();
-			Version version = dm.checkin(null, docId, is, comment);
+			Version version = dm.checkin(null, docId, is, comment, increment);
 			IOUtils.closeQuietly(is);
 			log.debug("checkin: {}", version);
 			return version;


### PR DESCRIPTION
The "increment" version field was not being used.
this PR fixes this issue during check-in operation